### PR TITLE
[ContributorsFromGit] -> [Git::Contributors]

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Author/BBYRD.pm
+++ b/lib/Dist/Zilla/PluginBundle/Author/BBYRD.pm
@@ -157,8 +157,8 @@ sub configure {
       }],
 
       #
-      # [ContributorsFromGit]
-      'ContributorsFromGit',
+      # [Git::Contributors]
+      'Git::Contributors',
    );
 
    # Handle $resources->{x_IRC}


### PR DESCRIPTION
The latter has fewer prerequisites and does not have issues on MSWin32.
